### PR TITLE
Feature/hex to rgb

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 import functions from '../utils/functions'
-import { getRGBValues, getChangingDimension} from '../utils/colorConvert'
+import { 
+  getRGBValues,
+  getChangingDimension,
+  checkColorType,
+  hexToRGB
+} from '../utils/colorConvert'
 import {useState, useEffect} from 'react'
 
 //usePhysColor hook
@@ -9,23 +14,38 @@ function usePhysColor(userOptions = {}) {
     style: {}, 
     syncTime: false,
     colorRange: {
-      from: {r:0, g:0, b:80, a:1},
-      to: {r:0, g:0, b:255, a:1}
+      from: {r:0, g:0, b:0, a:1},
+      to: {r:3, g:0, b:0, a:1}
     }
   }
-
-  //Add code here to check if colorRange from and to contain hex values, if so, convert to rgb
-
+  let from;
+  let to;
+  let dimension;
   
-  //Also create variable indicating which dimension is changing
-
-  let dimension = getChangingDimension(options.colorRange.from, options.colorRange.to)
+  //assumes userOptions.colorRange object key values are strings
   if (userOptions.colorRange) {
-    const from = getRGBValues(userOptions.colorRange.from)
-    const to = getRGBValues(userOptions.colorRange.to)
+    switch (checkColorType(userOptions.colorRange.from)) {
+      case 'hex': 
+        from = hexToRGB(userOptions.colorRange.from)
+        break
+      case 'rgb':
+        from = getRGBValues(userOptions.colorRange.from)
+        break
+    };
+    switch (checkColorType(userOptions.colorRange.to)) {
+      case 'hex': 
+        to = hexToRGB(userOptions.colorRange.to)
+        break
+      case 'rgb':
+        to = getRGBValues(userOptions.colorRange.to)
+        break
+    };
     dimension = getChangingDimension(from, to)
+  } else {
+    //default options
+    dimension = getChangingDimension(options.colorRange.from, options.colorRange.to)
   }
-
+  
   Object.assign(options, userOptions)
   const [_style, _setStyle] = useState({...options.style})
   const [internalCounter, setInternalCounter] = useState(0) 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function usePhysColor(userOptions = {}) {
     syncTime: false,
     colorRange: {
       from: {r:0, g:0, b:0, a:1},
-      to: {r:3, g:0, b:0, a:1}
+      to: {r:0, g:0, b:255, a:1}
     }
   }
   let from;

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ function usePhysColor(userOptions = {}) {
 
   //Add code here to check if colorRange from and to contain hex values, if so, convert to rgb
 
+  
   //Also create variable indicating which dimension is changing
 
   let dimension = getChangingDimension(options.colorRange.from, options.colorRange.to)


### PR DESCRIPTION
Did a bit of refactoring, but most of the original code should still be there.

Added:
* Switch cases that check the `from` and `to` values of `userOptions.colorRange` and see if they're hex or rgb
* If for some reason the dev decided to mix and match hex and rgb, it should still work (eg: `from: "#000000" to: "rgb(0, 100, 0)"` for `userOptions.colorRange`)
* If no `userOptions.colorRange`, defaults to `options`
* There will probably be a bug if the user doesn't include both `from` and `to` options, so the hook would need to Throw